### PR TITLE
Unit-testing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,17 @@
-
 name := "implicit-collector"
 version := "0.1"
 scalaVersion := "2.12.4"
 libraryDependencies ++= Seq(
     "org.scalameta" %% "testkit" % "2.1.2",
-    "com.github.scopt" % "scopt_2.12" % "3.7.0"
+
+  // not sure why we need the explicit _2.12.4
+  // but it does not work with it
+  // perhaps a question for Olaf
+    "org.scalameta" % "semanticdb-scalac_2.12.4" % "2.1.2",
+    "org.scala-lang" % "scala-compiler" % scalaVersion.value,
+    "com.github.scopt" % "scopt_2.12" % "3.7.0",
+    "org.scalactic" %% "scalactic" % "3.0.4",
+    "org.scalatest" %% "scalatest" % "3.0.4" % "test"
 )
 
 scalacOptions += "-Yno-adapted-args"

--- a/src/main/scala/extractor/ImplicitParamsToCSV.scala
+++ b/src/main/scala/extractor/ImplicitParamsToCSV.scala
@@ -6,7 +6,15 @@ import org.langmeta.inputs.Input
 
 import scala.meta._
 
+// TODO: this should be called like ExtractImplicits
 object ImplicitParamsToCSV {
+
+  final case class Result(
+     params: Set[ImplicitParam],
+     funs: Seq[FunApply],
+     links: Set[FunApplyWithImplicitParam],
+     implicits: Set[DeclaredImplicit])
+
   /**
     * Function that, given a queue of `results`, condenses them into a single map,
     * performing project-wide modifications (e.g. Remove project-wide duplicates on params)
@@ -35,6 +43,11 @@ object ImplicitParamsToCSV {
       )
       case (k, v) => (k, v)
     }
+  }
+
+  def process(db: Database): Result = {
+    // TODO: the code from apply should move here and then it should be called apply
+    Result(Set(), Seq(), Set(), Set())
   }
 
   def apply(walker: SemanticDBWalker): Map[String, Iterable[CSV.Serializable]] = {

--- a/src/test/scala/ExampleTest.scala
+++ b/src/test/scala/ExampleTest.scala
@@ -1,0 +1,18 @@
+class ExampleTest extends SemanticdbTest {
+
+  checkExtraction("""
+      |object ForCompImplicits {
+      |  import scala.concurrent.ExecutionContext.Implicits.global
+      |  for {
+      |    a <- scala.concurrent.Future.successful(1)
+      |    b <- scala.concurrent.Future.successful(2)
+      |    if a < b
+      |  } yield a
+      |}
+      """.trim.stripMargin, { result =>
+
+    result.funs shouldBe empty
+
+  })
+
+}

--- a/src/test/scala/SemanticdbTest.scala
+++ b/src/test/scala/SemanticdbTest.scala
@@ -1,0 +1,114 @@
+import java.io.{File, UncheckedIOException}
+import java.net.URLClassLoader
+import java.nio.file.{AccessDeniedException, Files}
+
+import extractor.ImplicitParamsToCSV
+import org.langmeta.internal.semanticdb.{schema => s}
+import org.langmeta.semanticdb.Database
+import org.scalatest.{FunSuite, Matchers}
+
+import scala.compat.Platform.EOL
+import scala.meta.internal.semanticdb.{DatabaseOps, FailureMode, ProfilingMode, SemanticdbMode}
+import scala.meta.io.AbsolutePath
+import scala.tools.cmd.CommandLineParser
+import scala.tools.nsc.{CompilerCommand, Global, Settings}
+import scala.util.{Failure, Success, Try}
+
+
+abstract class SemanticdbTest extends FunSuite with Matchers {
+  private val workingDir = File.createTempFile("semanticdb-test", "").getParentFile
+
+  private lazy val g: Global = {
+    val semanticdbPluginPath: String = {
+      val semanticdbPluginPathProperty = "semanticdb-scalac-jar"
+
+      val candidate = Option(System.getProperty(semanticdbPluginPathProperty, null)).getOrElse(Try {
+        // this is ugly for it is just for our tests, we can live with that
+        val cl = classOf[org.langmeta.semanticdb.Database].getClassLoader.asInstanceOf[URLClassLoader]
+        cl.getURLs
+          .map(_.getFile)
+          .filter(_.matches(".*/semanticdb-scalac[^jar]*jar$"))
+          .head
+      } match {
+        case Success(file) => file
+        case Failure(e) =>
+          e.printStackTrace(System.err)
+
+          fail("unable to figure out the path of semanticdb-scalac.jar. " +
+            s"Please set it up manually using -D$semanticdbPluginPathProperty", e)
+      })
+
+      assert(new File(candidate).exists())
+
+      candidate
+    }
+
+    val options = s"-Xplugin:$semanticdbPluginPath -Yrangepos -Xplugin-require:semanticdb"
+    val args = CommandLineParser.tokenize(options)
+
+    val emptySettings = new Settings(error => fail(s"couldn't apply settings because $error"))
+    emptySettings.usejavacp.value = true
+    emptySettings.outputDirs.setSingleOutput(workingDir.getCanonicalPath)
+
+    val command = new CompilerCommand(args, emptySettings)
+    new Global(command.settings)
+  }
+
+  private lazy val databaseOps: DatabaseOps = new DatabaseOps {
+    val global: Global = SemanticdbTest.this.g
+  }
+
+  import databaseOps._
+
+  config.setMode(SemanticdbMode.Slim)
+  config.setFailures(FailureMode.Error)
+  config.setProfiling(ProfilingMode.Console)
+
+  //  databaseOps.config.setSourceroot(AbsolutePath(workingDir))
+  config.setSourceroot(AbsolutePath(workingDir))
+
+  def computeSemanticdbFromCode(code: String): Database = {
+    val testFile = File.createTempFile("semanticdb-test-", ".scala")
+    val semanticdbFile = new File(workingDir, testFile.getName.replaceFirst("\\.scala$", ".semanticdb"))
+
+    // we have set up the compiler to use the working dir
+    // if this does not hold, we won't find the semanticsdb file
+    assert(testFile.getParentFile.getCanonicalPath == workingDir.getCanonicalPath)
+
+    Files.write(testFile.toPath, code.getBytes)
+
+    try {
+      new g.Run().compile(List(testFile.getCanonicalPath))
+    } catch {
+      case e: UncheckedIOException if e.getCause.isInstanceOf[AccessDeniedException] && semanticdbFile.exists() =>
+        // there is a bug in scalameta trying to access files it should not
+        // ignore it if it generated file
+      case e: Throwable => fail(s"Unable to compile", e)
+    } finally {
+      assert(testFile.delete())
+    }
+
+    if (!semanticdbFile.exists()) {
+      fail(s"Unable to find semanticdb file - expected at `${semanticdbFile.getCanonicalPath}'")
+    }
+
+    val sdb = s.Database.parseFrom(Files.readAllBytes(semanticdbFile.toPath))
+    sdb.toDb(None)
+  }
+
+  private def test(code: String)(fn: => Unit): Unit = {
+    var name = code.trim.replace(EOL, " ")
+    if (name.length > 50) name = name.take(50) + "..."
+    super.test(name)(fn)
+  }
+
+  protected def checkExtraction(code: String, f: ImplicitParamsToCSV.Result => Unit): Unit = {
+    test(code) {
+      val db = computeSemanticdbFromCode(code)
+      val result = ImplicitParamsToCSV.process(db)
+
+      f(result)
+    }
+  }
+
+}


### PR DESCRIPTION
This is a draft, but the idea should be already present.

It requires some changes in the ImplicitContextCSV. Once the other PR is done I can rework this one against master.

The way it works is that it compiles a snippet programatically using the semanticdb plugin and then let one asserts expectations about the results.

I would like to move from the `Map[String, Iterable[Serializable]]` to `Result`since at that level we are still working with a model. Only when we store the files we want them in CSV format.