### PR TITLE
Add support for differentiating test and compile paths

### DIFF
--- a/scripts/run.py
+++ b/scripts/run.py
@@ -657,14 +657,10 @@ def merge_paths(
     if exclude_unfinished:
         projects = P.exclude_non_successful(projects)
     paths_files = load_many(map(lambda p: os.path.join(p, reports_folder, "paths.csv"), projects))
-    augmented = merge_all(
-        map(
-            lambda (proj, paths_csv): extend_csv(paths_csv, "project", os.path.split(proj)[1]), 
-            zip(projects, paths_files))
-    )
+    merged = merge_all(paths_files)
     
     with open("paths.all.csv", 'w') as pathsfile:
-        pathsfile.write(print_csv(augmented))
+        pathsfile.write(print_csv(merged))
 
 ####################
 # CSVManip

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -639,10 +639,14 @@ $2 ~ /^\// { path = $2; print title ", " path ", " kind; title = "garbage"; kind
 @task
 def merge_paths(
     project_depth=BASE_CONFIG["default_location_depth"],
-    projects_path=BASE_CONFIG["projects_dest"]
+    projects_path=BASE_CONFIG["projects_dest"],
+    exclude_unfinished=True
 ):
+    P = Pipeline()
     reports_folder = BASE_CONFIG["reports_folder"]
     projects = get_project_list(projects_path, project_depth)
+    if exclude_unfinished:
+        projects = P.exclude_non_successful(projects)
     paths_files = load_many(map(lambda p: os.path.join(p, reports_folder, "paths.csv"), projects))
     augmented = merge_all(
         map(
@@ -650,7 +654,7 @@ def merge_paths(
             zip(projects, paths_files))
     )
     
-    with open("paths_all.csv", 'w') as pathsfile:
+    with open("paths.all.csv", 'w') as pathsfile:
         pathsfile.write(print_csv(augmented))
 
 ####################


### PR DESCRIPTION
This extension to the pipeline adds two new commands, to be able to determine whether a file belongs to a test or compile artifact:

- `extract_paths(project_path)`: Uses sbt to generate a csv file with the paths of the project, [such as this one](https://gist.github.com/blorente/0703ad164e0bb42dba3e75a72d435fcf)
- `merge_paths()`: Merges all the csvs generated previously.

## Implementation

It takes advantage of SBT's configurable source paths, requesting both test and compile paths, like so:
```
// At workshop
> show test:scalaSource
[info] coreutils/test:scalaSource
[info] 	/home/borja/work/scala/workshop/core/src/test/scala
[info] macros/test:scalaSource
[info] 	/home/borja/work/scala/workshop/macros/src/test/scala
[info] queries/test:scalaSource
[info] 	/home/borja/work/scala/workshop/queries/src/test/scala
[info] implicitExtractor/test:scalaSource
[info] 	/home/borja/work/scala/workshop/extractor/src/test/scala
[info] root/test:scalaSource
[info] 	/home/borja/work/scala/workshop/src/test/scala
```

Then it uses a function to create an AWK script that will output the correct thing.

## Possible changes

We might want to include all these metadata generations (sloc counts, classpath, this one...) in the same command as `create_project_info`, just for convenience. It may make things faster too, since we might save some SBT spinups.

We might want to separate paths by SBT projects. That can be done, and in fact, the first commits did it, but it didn't work in all cases and I ditched it for simplicity since we don't consider separate SBT projects anywhere else.