### PR TITLE
Integrate new path information into queries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,8 @@ lazy val coreutils = (project in file("core"))
       "com.github.nikita-volkov" % "sext" % "0.2.4",
       "io.suzaku" %% "boopickle" % "1.2.6",
       "org.json4s" %% "json4s-native" % "3.6.0-M2",
-      "com.lihaoyi" %% "scalatags" % "0.6.7"
+      "com.lihaoyi" %% "scalatags" % "0.6.7",
+      "com.github.tototoshi" %% "scala-csv" % "1.3.5"
     )
   )
 lazy val macros = (project in file("macros"))

--- a/core/src/main/scala/cz/cvut/fit/prl/scalaimplicit/core/reports/ProjectReport.scala
+++ b/core/src/main/scala/cz/cvut/fit/prl/scalaimplicit/core/reports/ProjectReport.scala
@@ -35,9 +35,10 @@ object ProjectReport extends LazyLogging {
         children.toParArray.map {
           case JObject(
               List(JField("metadata", JString(metadataPath)),
-                   JField("results", JString(resultsPath)))) =>
+                   JField("results", JString(resultsPath)),
+                   JField("paths", JString(pathsPath)))) =>
             logger.debug(s"Loading ${resultsPath}")
-            ProjectReport(ProjectMetadata.loadFromCSV(metadataPath),
+            ProjectReport(ProjectMetadata.loadFromCSV(metadataPath, pathsPath),
                           JSONSerializer.loadJSON(resultsPath))
         }.arrayseq
     }

--- a/notes/results/conversions.Rmd
+++ b/notes/results/conversions.Rmd
@@ -20,7 +20,11 @@ knitr::opts_chunk$set(
 library(readr)
 library(dplyr)
 library(calibrate)
-results_summary <- read_csv("~/work/scala/results/conversion/results.callsite.summary.csv") %>% 
+results_summary <- read_csv("~/work/scala/tmp/results/conversion/results.callsite.summary.csv") %>%
+  mutate(transitive = !transitive) # Should fix that in the impl
+in_main = read_csv("~/work/scala/tmp/results/conversion/in-main/results.callsite.summary.csv") %>%
+  mutate(transitive = !transitive) # Should fix that in the impl
+in_test = read_csv("~/work/scala/tmp/results/conversion/in-test/results.callsite.summary.csv") %>%
   mutate(transitive = !transitive) # Should fix that in the impl
 ``` 
 
@@ -124,18 +128,26 @@ printgraph = function(data, names, title) {
 And finally, we can produce the graph
 
 ```{r}
-total = sumOccurrences(transitive_conversions)
-pietitle = paste("Distribution of transitive conversions by use ", total)
-names = c("Unknown", "Testing libraries", "ArrowAssoc", "scala.Predef", "scala.LowPriorityImplicits", "Quotes", "Scala Options", "Other Options", "Other scala", "Akka actor <-> scala")
-functions = c(knownTestingFramework, arrowAssoc, otherScalaPredefs, lowPrioImplicits, containsQuote, scalaOption, otherOptions, otherScala, akkaActor)
-distribution = Map({function(fun) sumOccurrences(filterName(transitive_conversions, fun))}, functions)
+draw_conversion_distribution = function (df, title = "Distribution of transitive conversions by use ") {
 
-withTotals = c(
-  sumOccurrences(remainder(transitive_conversions, functions)),
-  distribution
-)
+  functions = c(known_testing_framework, arrow_assoc, other_scala_predefs, low_prio_implicits, contains_quote, scala_option, other_options, other_scala, akka_actor)
+  total = sum_ocurrences(df)
+  pietitle = paste(title, total)
+  names = c("Unknown", "Testing libraries", "ArrowAssoc", "scala.Predef", "scala.LowPriorityImplicits", "Quotes", "Scala Options", "Other Options", "Other scala", "Akka actor <-> scala")
 
-printgraph(withTotals, names, pietitle)
+  distribution = Map({function(fun) sum_ocurrences(filter_name(df, fun))}, functions)
+
+  with_totals = c(
+    sum_ocurrences(remainder(df, functions)),
+    distribution(df)
+  )
+
+  printgraph(with_totals, names, pietitle)
+}
+
+draw_conversion_distribution(transitive_conversions)
+draw_conversion_distribution(transitive_in_main, "Distribution of transitive conversions by use IN MAIN ")
+draw_conversion_distribution(transitive_in_test, "Distribution of transitive conversions by use IN TEST ")
 ```
 
 # Non-transitive conversions

--- a/notes/results/conversions.Rmd
+++ b/notes/results/conversions.Rmd
@@ -29,55 +29,61 @@ results_summary <- read_csv("~/work/scala/results/conversion/results.callsite.su
 First we filter the dataset
 
 ```{r}
-transitive_conversions = results_summary[results_summary$transitive,] %>%
-  group_by(name) %>%
-  summarise(occurrences = sum(occurrences)) %>%
-  arrange(-occurrences)
+count_transitive = function(df) {
+  df[df$transitive,] %>%
+    group_by(name) %>%
+    summarise(occurrences = sum(occurrences)) %>%
+    arrange(-occurrences)
+}
+
+transitive_conversions = count_transitive(results_summary)
+transitive_in_main = count_transitive(in_main)
+transitive_in_test = count_transitive(in_test)
 ```
 
 Now we define the filters that we found for call sites:
 
 ```{r}
 
-knownTestingFramework = function(name) {
+known_testing_framework = function(name) {
   grepl("^utest", name) |
   grepl("^org.scalatest", name) |
   grepl("^org.specs2", name)
 }
 
-arrowAssoc = function(name) {
+arrow_assoc = function(name) {
   name == "scala.Predef.ArrowAssoc"
 }
 
-otherScalaPredefs = function(name) {
-  (grepl("^scala.Predef", name) & !arrowAssoc(name))
+other_scala_predefs = function(name) {
+  (grepl("^scala.Predef", name) & !arrow_assoc(name))
 }
 
-lowPrioImplicits = function(name) {
+low_prio_implicits = function(name) {
   grepl("scala.LowPriorityImplicits", name)
 }
 
-containsQuote = function(name) {
+contains_quote = function(name) {
   grepl("[qQ]uote", name)
 }
 
-scalaOption = function(name) {
+scala_option = function(name) {
   grepl("^scala.Option", name)
 }
 
-otherOptions = function(name) {
-  !scalaOption(name) &
+other_options = function(name) {
+  !scala_option(name) &
   grepl("Option", name)
 }
 
-otherScala = function(name) {
-  !arrowAssoc(name) &
-  !otherScalaPredefs(name) &
-  !scalaOption(name) &
+other_scala = function(name) {
+  !arrow_assoc(name) &
+  !other_scala_predefs(name) &
+  !scala_option(name) &
   grepl("^scala.", name)
 }
 
-akkaActor = function(name) {
+akka_actor = function(name) {
   grepl("^akka.actor.actorRef2Scala", name) |
   grepl("^akka.actor.scala2ActorRef", name)
 }
@@ -87,15 +93,15 @@ And some helper traversal functions:
 
 ```{r}
 
-filterName = function(df, f) {
+filter_name = function(df, f) {
   df[f(df$name),]
 }
 
-filterOccurrences = function(df, f) {
+filter_occurrences = function(df, f) {
   df[f(df$occurrences),]
 }
 
-sumOccurrences = function(df) {
+sum_ocurrences = function(df) {
   sum(df$occurrences)
 }
 
@@ -148,13 +154,13 @@ summary = nontransitive_conversions %>%
   summarise(occurrences = sum(occurrences)) %>%
   arrange(-occurrences)
 
-freqCounts = nontransitive_conversions %>%
+freq_counts = nontransitive_conversions %>%
   group_by(occurrences) %>%
   summarise(count = n()) %>%
   arrange(occurrences, count)
 plot(
-  x = as.integer(freqCounts$count), 
-  y = as.integer(freqCounts$occurrences), 
+  x = as.integer(freq_counts$count),
+  y = as.integer(freq_counts$occurrences),
   log="yx", 
   xlab = "Number of implicits with that frequence",
   ylab= "Frequence: Number of conversions by this implicit", 
@@ -167,13 +173,13 @@ This is not extremely useful, unfortunately.
 Now, if we _don't_ mush the projects together, maybe we can gather some metadata. First, load the project stats.
 
 ```{r}
-project_metadata <- read_csv("~/work/scala/results/project_metadata.csv")
+project_metadata <- read_csv("~/work/scala/tmp/results/project-metadata.csv")
 ```
 
 Then, add LOC information to the nontransitive conversions:
 
 ```{r}
-locDistribution = 
+loc_distribution =
   left_join(nontransitive_conversions, project_metadata, by=c("project" = "reponame")) %>%
   mutate(name = name.x) %>%
   group_by(project) %>%
@@ -187,15 +193,15 @@ relevantNames = function(df) {
 }
 
 plot(
-  x = as.integer(locDistribution$scala_loc),
-  y = as.integer(locDistribution$occurrences), 
+  x = as.integer(loc_distribution$scala_loc),
+  y = as.integer(loc_distribution$occurrences),
   xlab = "Scala LOC", 
   ylab = "Non-transitive implicit conversions", 
   main="Distribution of non-transitive implicit conversions by scala LOC"
   )
 textxy(
-  locDistribution$scala_loc, 
-  locDistribution$occurrences,
-  locDistribution$project
+  loc_distribution$scala_loc,
+  loc_distribution$occurrences,
+  loc_distribution$project
   )
 ```

--- a/queries/src/main/scala/cz/cvut/fit/prl/scalaimplicit/queries/Main.scala
+++ b/queries/src/main/scala/cz/cvut/fit/prl/scalaimplicit/queries/Main.scala
@@ -10,5 +10,8 @@ object Main {
     PredefinedQueries.declarationsByCallSite()
     PredefinedQueries.moreThanOneParam()
     PredefinedQueries.typeClassClassification()
+    PredefinedQueries.mainTest()
+    PredefinedQueries.conversionInMain()
+    PredefinedQueries.conversionInTest()
   }
 }

--- a/queries/src/main/scala/cz/cvut/fit/prl/scalaimplicit/queries/OutputHelper.scala
+++ b/queries/src/main/scala/cz/cvut/fit/prl/scalaimplicit/queries/OutputHelper.scala
@@ -2,10 +2,17 @@ package cz.cvut.fit.prl.scalaimplicit.queries
 
 import java.nio.file.{Files, Paths}
 
-import cz.cvut.fit.prl.scalaimplicit.core.extractor.representation.Representation.{Argument, ImplicitArgument}
+import cz.cvut.fit.prl.scalaimplicit.core.extractor.representation.Representation.{
+  Argument,
+  ImplicitArgument
+}
 import cz.cvut.fit.prl.scalaimplicit.core.extractor.serializers.HTMLSerializer
 import cz.cvut.fit.prl.scalaimplicit.core.extractor.serializers.HTMLSerializer.TCFamily
-import cz.cvut.fit.prl.scalaimplicit.core.reports.{DefinitionSummary, ReportSummary, SlimReport}
+import cz.cvut.fit.prl.scalaimplicit.core.reports.{
+  DefinitionSummary,
+  ReportSummary,
+  SlimReport
+}
 import org.json4s.{NoTypeHints, ShortTypeHints}
 import org.json4s.native.Serialization
 import org.json4s.native.Serialization.write

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -536,10 +536,10 @@ def condense_reports(
             manifest_file.write("{\"projects\":[\n")
             for proj in manifest[:-1]:
                 if os.path.exists(proj[0]) and os.path.exists(proj[1]): 
-                    manifest_file.write("{\"metadata\":\"%s\",\"results\":\"%s\"},\n" % (proj[0], proj[1]))
+                    manifest_file.write("{\"metadata\":\"%s\",\"results\":\"%s\", \"paths\":\"%s\"},\n" % (proj[0], proj[1], proj[2]))
             last = manifest[-1]
             if os.path.exists(last[0]) and os.path.exists(last[1]): 
-                manifest_file.write("{\"metadata\":\"%s\",\"results\":\"%s\"}\n" % (last[0], last[1]))
+                manifest_file.write("{\"metadata\":\"%s\",\"results\":\"%s\", \"paths\":\"%s\"}\n" % (last[0], last[1], last[2]))
             manifest_file.write("]}")
 
     cwd = os.getcwd()
@@ -567,7 +567,11 @@ def condense_reports(
                 res = ((1, 0) if status.startswith("SUCCESS") else (0, 1))
                 reports[report] = tuple(map(sum, zip(reports[report], res)))
             full_path = os.path.join(cwd, project_path)
-            manifest.append(("%s/project.csv" % full_path, "%s/%s/results.json" % (full_path, BASE_CONFIG["reports_folder"])))
+            manifest.append((
+                "%s/project.csv" % full_path,
+                "%s/%s/results.json" % (full_path, BASE_CONFIG["reports_folder"]),
+                "%s/%s/paths.csv" % (full_path, BASE_CONFIG["reports_folder"])
+            ))
         write_summary(reports, total_projects, report_file)
     write_manifest(manifest)
 


### PR DESCRIPTION
This PR implements two queries that can filter a call site by their location: Test or Main.

The implementation of the filters is in `PredefinedQueries.scala`, under the functions `isMain` and `isTest`. Examples of those queries can be found in `PredefinedQueries.conversionInMain()` and `PredefinedQueries.conversionInTest()`