### PR TITLE
Fix creation of some spurious folders

### DIFF
--- a/scripts/run.py
+++ b/scripts/run.py
@@ -85,15 +85,15 @@ class Pipeline():
                 failed = True
         return failed
 
-    def get_base_output_folder(self, project_path, reports_folder_name=BASE_CONFIG["reports_folder"]):
+    def get_base_output_folder(self, project_path, reports_folder_name=BASE_CONFIG["reports_folder"], create_if_missing=False):
         output_folder = os.path.join(os.getcwd(), project_path, reports_folder_name)
-        if not os.path.exists(output_folder):
+        if create_if_missing and (not os.path.exists(report_folder)):
             os.mkdir(output_folder)
         return output_folder
 
-    def get_phase_reports_folder(self, project_path, reports_folder_name=BASE_CONFIG["reports_folder"]):
-        report_folder = os.path.join(self.get_base_output_folder(project_path, reports_folder_name), BASE_CONFIG["phase_reports_folder"])
-        if not os.path.exists(report_folder):
+    def get_phase_reports_folder(self, project_path, reports_folder_name=BASE_CONFIG["reports_folder"], create_if_missing=False):
+        report_folder = os.path.join(self.get_base_output_folder(project_path, reports_folder_name, create_if_missing), BASE_CONFIG["phase_reports_folder"])
+        if create_if_missing and (not os.path.exists(report_folder)):
             os.mkdir(report_folder)
         return report_folder
 
@@ -113,7 +113,7 @@ class Pipeline():
         return res if res is None else res.strip()
 
     def write_phase_report(self, content, project_path, kind):
-        report_folder = self.get_phase_reports_folder(project_path)
+        report_folder = self.get_phase_reports_folder(project_path, create_if_missing=True)
         report_path = os.path.join(report_folder, BASE_CONFIG["phase_reports"][kind])
         with open(report_path, 'w') as report:
             return report.write(content)
@@ -544,10 +544,10 @@ def merge_metadata(
         metadata.write(print_csv(projects_info))
     sloc_files = [proj+"/sloc.csv" for proj in projects]
     sloc_csvs = load_many(sloc_files)
-    headers_clean = [drop_header(csvf, 5) for csvf in sloc_csvs] # Drop the annoying cloc timestamp
+    headers_clean = [(drop_header(csvf, 5) if len(csvf["headers"]) == 6 else csvf) for csvf in sloc_csvs] # Drop the annoying cloc timestamp
     with_project = [extend_csv(headers_clean[i], "project", get_data(metadata_files[i], 0, "reponame")) for i in range(0, len(headers_clean))]
     all_in_one = merge_all(with_project)
-    with open("slocs.csv", 'w') as slocs_file:
+    with open("slocs.all.csv", 'w') as slocs_file:
         slocs_file.write(print_csv(all_in_one))
 
 # Run sbt to extract test and compile source paths


### PR DESCRIPTION
When a process requested a project's `_reports` folder and that folder was not there, it created the necessary folders.

This becomes a problem when we execute some`fab merge_*` command and forget to pass the appropriate project depth. In those cases, the pipeline would create a whole new hierarchy of empty `_reports` folders.

To solve this we implement an optional parameter in the functions to retrieve the necessary `_reports` folders, so that the commands that only want to _read_ from those folders do not trigger the creation of empty directories.