### PR TITLE
Implement a master `merge` function

### DIFF
--- a/scripts/run.py
+++ b/scripts/run.py
@@ -87,7 +87,7 @@ class Pipeline():
 
     def get_base_output_folder(self, project_path, reports_folder_name=BASE_CONFIG["reports_folder"], create_if_missing=False):
         output_folder = os.path.join(os.getcwd(), project_path, reports_folder_name)
-        if create_if_missing and (not os.path.exists(report_folder)):
+        if create_if_missing and (not os.path.exists(output_folder)):
             os.mkdir(output_folder)
         return output_folder
 


### PR DESCRIPTION
This implements a master `merge` command that can be executed to extract all the information from the projects. Example run:

```
blorente@prl3:/var/lib/top-scala$ fab merge:project_depth=1
20:17:15.070484[Runner] Merging call site counts into callsite-counts.all.csv
20:17:15.098968[Runner] Merging paths into paths.all.csv
20:17:15.106631[Runner] Merging metadata into project-metadata.csv
20:17:15.107468[Runner] Merging sloc files into slocs.all.csv
20:17:15.109067[Runner][Reports] Generating analysis report into condensed-report.long.csv

Done.
```

- [X] Implement command
- [X] Generalize report names (e.g. make them all conform to `<name>.all.csv`)
- [X] Lift those names to BASE_CONFIG